### PR TITLE
Fixed complete failure due to spaces in input, added a test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+---
+name: Test
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Test a known input
+        uses: ./
+        id: known_input
+        with:
+          name: this is always the same string so it produces a known result
+
+      - name: Verify the output matches
+        run: |
+          if [[ "${{ steps.known_input.outputs.result}}" == "browny-manslaughter" ]]; then
+            echo "matches"
+          else
+            echo "'${{ steps.known_input.outputs.result}}' does not match"
+            exit 1
+          fi
+
+      - name: Test a different input
+        uses: ./
+        id: other_input
+        with:
+          name: ${{ github.run_id }}
+
+      - name: Verify the output is different
+        run: |
+          if [[ "${{ steps.other_input.outputs.result}}" != "browny-manslaughter" ]]; then
+            echo "'${{ steps.other_input.outputs.result}}' was different as expected"
+          else
+            echo "was the same as the known input, which is not right"
+            exit 1
+          fi
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-branch_name=$1
+export branch_name="$1"
 
 spicy_proton_name=$(ruby -rspicy-proton -rdigest/sha1 -e'
-  branch_name_hash = Digest::SHA1.hexdigest("'${branch_name}'").to_i(16)
+  branch_name_hash = Digest::SHA1.hexdigest(ENV["branch_name"]).to_i(16)
   words            = Spicy::Proton.new
   adjective        = words.adjectives[branch_name_hash % words.adjectives.length]
   noun             = words.nouns[branch_name_hash % words.nouns.length]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 branch_name=$1
 
 spicy_proton_name=$(ruby -rspicy-proton -rdigest/sha1 -e'


### PR DESCRIPTION
The issue: if a space exists in the input string, the action will fail with a syntax error.

The fix: use an environment variable to hand the input string to the ruby command, instead of interpolating it.

Also: added tests!
